### PR TITLE
Amend off-by-one error in branch ID

### DIFF
--- a/TreeGen.py
+++ b/TreeGen.py
@@ -122,11 +122,11 @@ def loop(itree):
             
             if Np>1 and cfg.M0>cfg.Mres: # register next-level branches
             
-                Nbranch += 1
                 Mak_tmp.append(M2)
                 zak_tmp.append(cfg.z0)
                 idk_tmp.append(Nbranch)
                 ipk_tmp.append(id)
+                Nbranch += 1
             
             # record the mass history at the original time resolution
             M.append(cfg.M0)

--- a/TreeGen_Sub.py
+++ b/TreeGen_Sub.py
@@ -123,11 +123,11 @@ def loop(itree):
             
             if Np>1 and cfg.M0>cfg.Mres: # register next-level branches
             
-                Nbranch += 1
                 Mak_tmp.append(M2)
                 zak_tmp.append(cfg.z0)
                 idk_tmp.append(Nbranch)
                 ipk_tmp.append(id)
+                Nbranch += 1
             
             # record the mass history at the original time resolution
             M.append(cfg.M0)


### PR DESCRIPTION
When generating descendants of branch 0, `Nbranch` is set to 1. Incrementing `Nbranch` _before_ appending to the branch ID list causes the first descendant of branch 0 to be recorded with ID 2 rather than 1. This leads to the row with index 1 being skipped in all output arrays. Incrementing `Nbranch` after recording the new branch's ID fixes this issue. 